### PR TITLE
DONDEV-10 | 05/16 rate limiting on contact POST + README synced to th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,31 +11,39 @@ A web application for Pitt Stop Ministries, built by Keshon for Pastor Keyubba B
 - **Logging:** morgan
 - **Dev Server:** nodemon
 - **Email:** @getbrevo/brevo — transactional API for contact form
+- **Rate Limiting:** express-rate-limit — IP-based throttling on sensitive endpoints
 
 ## Project Structure
 
 ```
 pit_stop_ministries/
-├── index.js              # Entry point — Express server config
+├── index.js                  # Entry point — Express server config
 ├── middleware/
-│   └── errorHandler.js   # Centralized error handling
-├── models/               # Data models (coming soon)
+│   └── errorHandler.js       # Centralized error handling
+├── models/                   # Data models (coming soon)
 ├── routes/
-│   ├── donations.js      # Donations page route
-│   └── contacts.js       # Contact form GET/POST + Brevo relay
+│   ├── donations.js          # Donations page route
+│   ├── sermons.js            # Sermons page route
+│   └── contacts.js           # Contact form GET/POST + Brevo relay
 ├── services/
-│   └── email.js          # Brevo transactional email client
+│   ├── email.js              # Brevo transactional email client
+│   ├── validateContact.js    # Server-side validation for contact fields
+│   └── rateLimiter.js        # express-rate-limit config (5/15min per IP)
 ├── views/
 │   ├── donations.ejs
+│   ├── sermons.ejs
 │   ├── contacts.ejs
+│   ├── contact-success.ejs   # Post-submit confirmation (also used for honeypot deception)
 │   └── partials/
-│       └── nav.ejs       # Shared navigation partial
+│       ├── nav.ejs           # Shared navigation partial
+│       ├── head.ejs          # Shared <head> partial
+│       └── footer.ejs        # Shared footer partial
 ├── public/
-│   ├── css/              # Page styles + shared nav styles
+│   ├── css/                  # Per-page styles + shared nav styles
 │   └── js/
-│       └── nav.js        # Hamburger toggle + ARIA sync
-├── .env                  # Environment variables (not committed)
-├── .env.example          # Template for required env vars
+│       └── nav.js            # Hamburger toggle + ARIA sync
+├── .env                      # Environment variables (not committed)
+├── .env.example              # Template for required env vars
 └── package.json
 ```
 
@@ -68,8 +76,9 @@ The server runs on `http://localhost:3000` by default (configurable via `PORT` i
 
 - `GET /` — API health check response
 - `GET /donations` — renders donations page with embedded Tithe.ly Give widget
+- `GET /sermons` — renders sermons page
 - `GET /contacts` — renders contact form
-- `POST /contacts` — relays submission to Pastor Bowman via Brevo
+- `POST /contacts` — rate-limited (5/15min per IP), honeypot-checked, validated, then relays to Pastor Bowman via Brevo
 
 Each page route passes `currentPage` to its template so the shared nav partial can mark the active link.
 
@@ -84,7 +93,7 @@ Shared `views/partials/nav.ejs` partial included by every page.
 
 Behavior wired from `public/js/nav.js`, loaded via `<script src="/js/nav.js" defer></script>` on each page that includes the partial.
 
-## Contact Page (In Progress)
+## Contact Page
 
 Form collects: name, email, category dropdown, message.
 
@@ -94,14 +103,28 @@ Form collects: name, email, category dropdown, message.
 
 **Email delivery:** Brevo transactional API relays submissions to Pastor Bowman's inbox via `services/email.js`. Direct SMTP credentials never touch the codebase. Set `BREVO_API_KEY` in `.env` (sender domain SPF/DKIM verification still pending for production).
 
+**Spam & abuse protection — three-layer defense on `POST /contacts`:**
+
+1. **Rate limiting** (`services/rateLimiter.js`) — Cheapest, broadest gate. 5 submissions per 15 minutes per IP, returns HTTP 429 with a friendly retry message. Mounted as middleware on the POST route so it runs before any other logic.
+2. **Honeypot** (`routes/contacts.js`) — Hidden `website` input rendered off-screen with `aria-hidden="true"` and `tabindex="-1"` so screen readers and keyboard users skip it, but bots filling every field will trip it. Triggered submissions are logged server-side with IP + identifying info, then rendered a **fake success page** so the attacker doesn't learn the trap exists.
+3. **Validation** (`services/validateContact.js`) — Server-side checks on name (1–100), email (6–254 + format), category (whitelist), and message (10–2000). EJS templates auto-escape via `<%= %>` so any returned user input is XSS-safe. Errors render back to the form with the original values preserved.
+
+Defense is intentionally layered: each gate is cheaper and broader than the next. A bot has to rotate IPs faster than 5/15min, *and* not fill the honeypot, *and* pass validation, before the email send is even attempted.
+
+## Sermons Page
+
+Renders a list of sermons (currently scaffolded; YouTube channel embed pending). Route at `routes/sermons.js`, view at `views/sermons.ejs`, styles at `public/css/sermons.css`.
+
 ## Roadmap
 
 - [x] Foundation infrastructure
 - [x] Donations route + Tithe.ly widget embed
 - [x] Shared nav partial + mobile hamburger + active-state styling
-- [x] Contact form scaffold + Brevo email service
+- [x] Contact form: scaffold + Brevo email + validation + honeypot + rate limiting
+- [x] Sermons page (scaffold)
+- [ ] Contact page design pass (CSS, favicon, accessibility polish)
+- [ ] Sermons page: YouTube channel embed + design pass
 - [ ] Crisis interception JS for emergency category
-- [ ] Sermons page (YouTube channel embed)
 - [ ] Events page
 - [ ] Home page (built last, after all sub-pages exist)
-- [ ] Auth0 integration (Phase 2)
+- [ ] Auth0 integration (Phase 2 — user accounts for Pastor Bowman to manage content)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^17.4.0",
         "ejs": "^5.0.1",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "morgan": "^1.10.1"
       },
       "devDependencies": {
@@ -409,6 +410,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -629,6 +648,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^17.4.0",
     "ejs": "^5.0.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "morgan": "^1.10.1"
   },
   "devDependencies": {

--- a/routes/contacts.js
+++ b/routes/contacts.js
@@ -2,12 +2,13 @@ const express = require('express');
 const router = express.Router();
 const { sendContactEmail } = require("../services/email");
 const { validateContact } = require("../services/validateContact");
+const { limiter } = require("../services/rateLimiter");
 
 router.get("/", (req, res) => {
     res.render('contacts', { currentPage: 'contacts', errors: {}, values: {} });
 });
 
-router.post('/', async (req, res) => {
+router.post('/', limiter, async (req, res) => {
     // Honey pot verification
     if (req.body.website) {
         console.log('Honeypot triggered', {

--- a/services/rateLimiter.js
+++ b/services/rateLimiter.js
@@ -1,0 +1,18 @@
+const { rateLimit } = require('express-rate-limit');
+
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    limit: 5, // Limit each IP to 5 requests per 'window'
+    message: 'Too many submissions. Please wait a few minutes and try again.',
+    standardHeaders: true, // Return rate limit info in the 'RateLimit-x' headers
+    legacyHeaders: false, // Disable the X-RateLimit-* headers
+});
+
+module.exports = { limiter };
+
+/* Set a custom handler for more advanced use-cases, such as using res.render() to send a templated response.
+​
+statusCode
+number
+The HTTP status code to send back when a client is rate limited.
+Defaults to 429.*/


### PR DESCRIPTION
 - Install express-rate-limit; configure 5/15min per IP in services/rateLimiter.js
  - Mount as middleware on POST /contacts (before honeypot/validation)
  - Bring README up to date with sermons + contact form security stack