### PR TITLE
DONDEV-13 | 06/01 | Split README into orientation + move detail to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A web application for Pitt Stop Ministries, built by Keshon for Pastor Keyubba Bowman.
 
+> **Detailed documentation lives in the [Wiki](../../wiki).** This README is the orientation
+> layer — what the project is, how to run it, and where things stand. For how each subsystem
+> actually works (and why), follow the links in [Documentation](#documentation) below.
+
 ## Tech Stack
 
 - **Runtime:** Node.js
@@ -12,40 +16,6 @@ A web application for Pitt Stop Ministries, built by Keshon for Pastor Keyubba B
 - **Dev Server:** nodemon
 - **Email:** @getbrevo/brevo — transactional API for contact form
 - **Rate Limiting:** express-rate-limit — IP-based throttling on sensitive endpoints
-
-## Project Structure
-
-```
-pit_stop_ministries/
-├── index.js                  # Entry point — Express server config
-├── middleware/
-│   └── errorHandler.js       # Centralized error handling
-├── models/                   # Data models (coming soon)
-├── routes/
-│   ├── donations.js          # Donations page route
-│   ├── sermons.js            # Sermons page route
-│   └── contacts.js           # Contact form GET/POST + Brevo relay
-├── services/
-│   ├── email.js              # Brevo transactional email client
-│   ├── validateContact.js    # Server-side validation for contact fields
-│   └── rateLimiter.js        # express-rate-limit config (5/15min per IP)
-├── views/
-│   ├── donations.ejs
-│   ├── sermons.ejs
-│   ├── contacts.ejs
-│   ├── contact-success.ejs   # Post-submit confirmation (also used for honeypot deception)
-│   └── partials/
-│       ├── nav.ejs           # Shared navigation partial
-│       ├── head.ejs          # Shared <head> partial
-│       └── footer.ejs        # Shared footer partial
-├── public/
-│   ├── css/                  # Per-page styles + shared nav styles
-│   └── js/
-│       └── nav.js            # Hamburger toggle + ARIA sync
-├── .env                      # Environment variables (not committed)
-├── .env.example              # Template for required env vars
-└── package.json
-```
 
 ## Getting Started
 
@@ -62,58 +32,32 @@ npm run dev
 
 The server runs on `http://localhost:3000` by default (configurable via `PORT` in `.env`).
 
-## Infrastructure (Completed)
+## Project Structure
 
-- dotenv loaded as first line — environment variables available everywhere
-- EJS template engine configured with views directory
-- Static file serving from `public/`
-- JSON body parsing for POST requests (`express.json()`)
-- URL-encoded form body parsing (`express.urlencoded({ extended: true })`)
-- morgan request logging in dev mode
-- Centralized error handler — catches unhandled errors, returns clean 500 response
+```
+pit_stop_ministries/
+├── index.js          # Entry point — Express server config
+├── middleware/       # Centralized error handling
+├── models/           # Data models (coming soon)
+├── routes/           # Page routes + contact form handler
+├── services/         # Email, validation, rate limiting
+├── views/            # EJS templates + shared partials
+├── public/           # CSS + client-side JS
+├── .env.example      # Template for required env vars
+└── package.json
+```
 
-## Routes
+A file-by-file breakdown is in the wiki: **[Architecture & Infrastructure](../../wiki/Architecture-and-Infrastructure)**.
 
-- `GET /` — API health check response
-- `GET /donations` — renders donations page with embedded Tithe.ly Give widget
-- `GET /sermons` — renders sermons page
-- `GET /contacts` — renders contact form
-- `POST /contacts` — rate-limited (5/15min per IP), honeypot-checked, validated, then relays to Pastor Bowman via Brevo
+## Documentation
 
-Each page route passes `currentPage` to its template so the shared nav partial can mark the active link.
+The wiki holds the detailed reference for each part of the system:
 
-## Navigation
-
-Shared `views/partials/nav.ejs` partial included by every page.
-
-- **Desktop (≥ 769px):** persistent vertical rail on the left, dark background, white links
-- **Mobile (≤ 768px):** rail collapses to a 48×48px hamburger button (WCAG touch target); clicking toggles `.nav-links.open` to reveal the menu
-- **Active state:** matching link receives `aria-current="page"` from the route's `currentPage`, styled with gold + bold + left border (color-blind safe — three signals, not just color)
-- **Accessibility:** `aria-expanded` on the hamburger stays in sync with menu state for screen readers
-
-Behavior wired from `public/js/nav.js`, loaded via `<script src="/js/nav.js" defer></script>` on each page that includes the partial.
-
-## Contact Page
-
-Form collects: name, email, category dropdown, message.
-
-**Categories:** Prayer Request, Booking / Speaking, Marriage / Officiate, General Questions, Compliments / Testimonials, Suicidal / Emergency.
-
-**Crisis interception (planned):** when "Suicidal / Emergency" is selected, the page will immediately surface 988 crisis resources via JavaScript — submission pathway becomes secondary. A contact form is not a crisis tool.
-
-**Email delivery:** Brevo transactional API relays submissions to Pastor Bowman's inbox via `services/email.js`. Direct SMTP credentials never touch the codebase. Set `BREVO_API_KEY` in `.env` (sender domain SPF/DKIM verification still pending for production).
-
-**Spam & abuse protection — three-layer defense on `POST /contacts`:**
-
-1. **Rate limiting** (`services/rateLimiter.js`) — Cheapest, broadest gate. 5 submissions per 15 minutes per IP, returns HTTP 429 with a friendly retry message. Mounted as middleware on the POST route so it runs before any other logic.
-2. **Honeypot** (`routes/contacts.js`) — Hidden `website` input rendered off-screen with `aria-hidden="true"` and `tabindex="-1"` so screen readers and keyboard users skip it, but bots filling every field will trip it. Triggered submissions are logged server-side with IP + identifying info, then rendered a **fake success page** so the attacker doesn't learn the trap exists.
-3. **Validation** (`services/validateContact.js`) — Server-side checks on name (1–100), email (6–254 + format), category (whitelist), and message (10–2000). EJS templates auto-escape via `<%= %>` so any returned user input is XSS-safe. Errors render back to the form with the original values preserved.
-
-Defense is intentionally layered: each gate is cheaper and broader than the next. A bot has to rotate IPs faster than 5/15min, *and* not fill the honeypot, *and* pass validation, before the email send is even attempted.
-
-## Sermons Page
-
-Renders a list of sermons (currently scaffolded; YouTube channel embed pending). Route at `routes/sermons.js`, view at `views/sermons.ejs`, styles at `public/css/sermons.css`.
+- **[Architecture & Infrastructure](../../wiki/Architecture-and-Infrastructure)** — full project layout, Express setup, middleware chain
+- **[Routes](../../wiki/Routes)** — every endpoint and what it does
+- **[Navigation](../../wiki/Navigation)** — shared nav partial, mobile hamburger, active-state + accessibility
+- **[Contact Page](../../wiki/Contact-Page)** — form categories, crisis interception, Brevo email relay, 3-layer spam defense
+- **[Sermons Page](../../wiki/Sermons-Page)** — sermons list and YouTube embed plan
 
 ## Roadmap
 
@@ -128,3 +72,6 @@ Renders a list of sermons (currently scaffolded; YouTube channel embed pending).
 - [ ] Events page
 - [ ] Home page (built last, after all sub-pages exist)
 - [ ] Auth0 integration (Phase 2 — user accounts for Pastor Bowman to manage content)
+- [ ] Collapsible desktop/tablet nav rail with icon-only state (Phase 2 — requires icon library)
+- [ ] Cookie consent + SEO/analytics groundwork (Phase 2)
+- [ ] Refactor shared `<head>` content into `partials/head.ejs` (Phase 2 — prevents per-page script/CSS tag drift)


### PR DESCRIPTION
## What

Splits the README into two layers:

- **README** keeps the orientation content — description, tech stack, getting started, a condensed project structure, the roadmap, and a new **Documentation** section that links into the wiki.
- **Wiki** now holds the detailed reference: full file tree, infrastructure, routes, navigation deep-dive, the contact page (categories, crisis interception, Brevo relay, 3-layer spam defense), and the sermons page.

## Why

The README had grown into a full reference manual doing two jobs at once. A first-time reader had to scroll through subsystem internals to find "what is this and how do I run it." Detail now lives in the wiki; the README stays scannable.

## Wiki

Pages published to the [project wiki](https://github.com/KeshonsWalksOfLife/pit_stop_ministries/wiki): Home, Architecture & Infrastructure, Routes, Navigation, Contact Page, Sermons Page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)