### PR TITLE
v1 go-live: start script + Render blueprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js",
     "dev": "nodemon index.js"
   },
   "keywords": [],

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,14 @@
+# Render Blueprint — https://render.com/docs/blueprint-spec
+# Render dashboard: New + -> Blueprint -> connect this repo -> Render reads this file
+# and provisions the web service automatically. You only fill in the secret value.
+services:
+  - type: web
+    name: pitt-stop-ministries
+    runtime: node
+    plan: free
+    branch: main
+    buildCommand: npm install
+    startCommand: npm start
+    envVars:
+      - key: BREVO_API_KEY
+        sync: false   # set the real value in the Render dashboard; never commit it


### PR DESCRIPTION
Final deploy config so the v1 site can ship on a Node host (Render).

- `start` script (`node index.js`) so `npm start` boots the app
- `render.yaml` blueprint (node web service, `npm install` / `npm start`, `BREVO_API_KEY` as a non-synced secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)