### PR TITLE
Add sermon — The Pitt Stop | Jun 14, 2026

### DIFF
--- a/data/sermons.json
+++ b/data/sermons.json
@@ -1,5 +1,11 @@
 [
     {
+        "id": "1Lf6NOde1lE",
+        "title": "The Pitt Stop | Jun 14, 2026",
+        "date": "2026-06-14",
+        "description": ""
+    },
+    {
         "id": "wcJAUYcRgSM",
         "title": "The Pitt Stop | Jun 11, 2026",
         "date": "2026-06-11",

--- a/scripts/fetch_sermons.mjs
+++ b/scripts/fetch_sermons.mjs
@@ -8,6 +8,7 @@ const IDS = [
   "iuNGg-YXajM","w4h6O-YtBbA","22SW87w4IoE","zmzmNn19_yo","A57VnLJO-LU",
   "ZpNPgDE4wjU","U5BlO9X5vBw","R1UwUhxj4-s","3_yv4fpy_Kw",
   "66LYKyFTErk","Lc3rFWyxbD4","lzhuPs9Vj5c","_dmTOc-gcCc","PoYtXjGFj7g","vprdkqTC1Yo","wcJAUYcRgSM",
+  "1Lf6NOde1lE",
 ];
 
 const UA = "Mozilla/5.0";


### PR DESCRIPTION
Adds video `1Lf6NOde1lE` to the sermons library (now 31; newest → featured). Also appends the id to `scripts/fetch_sermons.mjs` so regenerations stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)