### PR TITLE
Add persistent rate limiting, hCaptcha verification, and Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+.env
+.git
+.gitignore
+data-runtime
+README.md
+WIKI.md

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 PORT=3000
 TITHELY_API_KEY=your_api_key_here
 BREVO_API_KEY=your_brevo_api_key_here
+HCAPTCHA_SITE_KEY=your_hcaptcha_site_key_here
+HCAPTCHA_SECRET_KEY=your_hcaptcha_secret_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # node module
 node_modules/
 
+# Persisted rate-limit counters (services/rateLimiter.js) — runtime state, not source
+data-runtime/
+
 # Environmental Variables
 .env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+# Install dependencies first so this layer is cached unless package*.json changes
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+# Rate-limit counters persist here (services/rateLimiter.js) — mount a volume
+# over this path (see docker-compose.yml) so counts survive container restarts.
+RUN mkdir -p /app/data-runtime && chown -R node:node /app/data-runtime
+ENV RATE_LIMIT_DATA_DIR=/app/data-runtime
+
+ENV NODE_ENV=production
+ENV PORT=3000
+EXPOSE 3000
+
+# Runs as the non-root "node" user built into the base image
+USER node
+
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ npm run dev
 
 The server runs on `http://localhost:3000` by default (configurable via `PORT` in `.env`).
 
+### Running with Docker
+
+```bash
+cp .env.example .env       # fill in BREVO_API_KEY, PORT, etc.
+docker compose up --build
+```
+
+Same app, same `.env`, running in a container on `http://localhost:3000`. The contact form's
+rate-limit counters (`services/rateLimiter.js`) are persisted to a named volume
+(`rate-limit-data`, mounted at `/app/data-runtime`) so they survive container restarts instead
+of silently resetting.
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The wiki holds the detailed reference for each part of the system:
 - **[Sermons Page](../../wiki/Sermons-Page)** — curated YouTube library, month categories, thumbnail-facade players
 - **[Pitt Stop (About) Page](../../wiki/Pitt-Stop-Page)** — Pastor Q hero, story, values
 - **[Donations Page](../../wiki/Donations-Page)** — Tithe.ly Give widget + brand framing
-- **[Contact Page](../../wiki/Contact-Page)** — form categories, crisis interception, Brevo email relay, 4-layer spam defense
+- **[Contact Page](../../wiki/Contact-Page)** — form categories, crisis interception, Brevo email relay, 5-layer spam defense
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The wiki holds the detailed reference for each part of the system:
 - **[Sermons Page](../../wiki/Sermons-Page)** — curated YouTube library, month categories, thumbnail-facade players
 - **[Pitt Stop (About) Page](../../wiki/Pitt-Stop-Page)** — Pastor Q hero, story, values
 - **[Donations Page](../../wiki/Donations-Page)** — Tithe.ly Give widget + brand framing
-- **[Contact Page](../../wiki/Contact-Page)** — form categories, crisis interception, Brevo email relay, 3-layer spam defense
+- **[Contact Page](../../wiki/Contact-Page)** — form categories, crisis interception, Brevo email relay, 4-layer spam defense
 
 ## Roadmap
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -32,7 +32,7 @@ pit_stop_ministries/
 ├── services/
 │   ├── email.js              # Brevo transactional email client
 │   ├── validateContact.js    # Server-side validation for contact fields
-│   └── rateLimiter.js        # express-rate-limit config (5/15min per IP)
+│   └── rateLimiter.js        # express-rate-limit config (5/15min per IP, 3/24h per email)
 ├── data/
 │   └── sermons.json          # Curated YouTube sermon library (id / title / date)
 ├── scripts/
@@ -80,7 +80,7 @@ pit_stop_ministries/
 | GET    | `/pittstop`        | Renders the Pitt Stop (About) page                                                                    |
 | GET    | `/donations`       | Renders donations page with embedded Tithe.ly Give widget                                             |
 | GET    | `/contacts`        | Renders contact form                                                                                  |
-| POST   | `/contacts`        | Rate-limited (5/15min per IP), honeypot-checked, validated, then relays to Pastor Bowman via Brevo    |
+| POST   | `/contacts`        | Rate-limited (5/15min per IP, 3/24h per email), honeypot-checked, validated, then relays to Pastor Bowman via Brevo |
 
 Each page route passes `currentPage` to its template so the shared nav partial can mark the active link with `aria-current="page"`.
 
@@ -116,13 +116,14 @@ Form collects: name, email, category dropdown, message.
 
 **Email delivery:** Brevo transactional API relays submissions to Pastor Bowman's inbox via `services/email.js`. Direct SMTP credentials never touch the codebase. Set `BREVO_API_KEY` in `.env` (sender domain SPF/DKIM verification still pending for production).
 
-**Spam & abuse protection — three-layer defense on `POST /contacts`:**
+**Spam & abuse protection — four-layer defense on `POST /contacts`:**
 
-1. **Rate limiting** (`services/rateLimiter.js`) — Cheapest, broadest gate. 5 submissions per 15 minutes per IP, returns HTTP 429 with a friendly retry message. Mounted as middleware on the POST route so it runs before any other logic.
-2. **Honeypot** (`routes/contacts.js`) — Hidden `website` input rendered off-screen with `aria-hidden="true"` and `tabindex="-1"` so screen readers and keyboard users skip it, but bots filling every field will trip it. Triggered submissions are logged server-side with IP + identifying info, then rendered a **fake success page** so the attacker doesn't learn the trap exists.
-3. **Validation** (`services/validateContact.js`) — Server-side checks on name (1–100), email (6–254 + format), category (whitelist), and message (10–2000). EJS templates auto-escape via `<%= %>` so any returned user input is XSS-safe. Errors render back to the form with the original values preserved.
+1. **IP rate limiting** (`services/rateLimiter.js` → `limiter`) — Cheapest, broadest gate. 5 submissions per 15 minutes per IP, returns HTTP 429 with a friendly retry message. Requires `app.set("trust proxy", 1)` in `index.js` to read the real visitor IP through Render's reverse proxy — without it, every request resolves to the same proxy address and the limiter effectively becomes one shared bucket for the whole site.
+2. **Email rate limiting** (`services/rateLimiter.js` → `emailLimiter`) — Catches a sender who spreads submissions across the day from the same address (e.g. one an hour) to stay under the IP window. Keys on the submitted `email` field instead of IP: 3 submissions per 24 hours per address, regardless of which IP they came from.
+3. **Honeypot** (`routes/contacts.js`) — Hidden `website` input rendered off-screen with `aria-hidden="true"` and `tabindex="-1"` so screen readers and keyboard users skip it, but bots filling every field will trip it. Triggered submissions are logged server-side with IP + identifying info, then rendered a **fake success page** so the attacker doesn't learn the trap exists.
+4. **Validation** (`services/validateContact.js`) — Server-side checks on name (1–100), email (6–254 + format), category (whitelist), and message (10–2000). EJS templates auto-escape via `<%= %>` so any returned user input is XSS-safe. Errors render back to the form with the original values preserved.
 
-Defense is intentionally layered: each gate is cheaper and broader than the next. A bot has to rotate IPs faster than 5/15min, *and* not fill the honeypot, *and* pass validation, before the email send is even attempted.
+Defense is intentionally layered: each gate is cheaper and broader than the next. A bot has to rotate IPs faster than 5/15min, *and* rotate email addresses faster than 3/24h, *and* not fill the honeypot, *and* pass validation, before the email send is even attempted.
 
 ## Donations Page
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -92,7 +92,7 @@ pit_stop_ministries/
 | GET    | `/pittstop`        | Renders the Pitt Stop (About) page                                                                    |
 | GET    | `/donations`       | Renders donations page with embedded Tithe.ly Give widget                                             |
 | GET    | `/contacts`        | Renders contact form                                                                                  |
-| POST   | `/contacts`        | Rate-limited (5/15min per IP, 3/24h per email), honeypot-checked, validated, then relays to Pastor Bowman via Brevo |
+| POST   | `/contacts`        | Rate-limited (5/15min per IP, 3/24h per email), honeypot-checked, hCaptcha-verified, validated, then relays to Pastor Bowman via Brevo |
 
 Each page route passes `currentPage` to its template so the shared nav partial can mark the active link with `aria-current="page"`.
 
@@ -128,14 +128,15 @@ Form collects: name, email, category dropdown, message.
 
 **Email delivery:** Brevo transactional API relays submissions to Pastor Bowman's inbox via `services/email.js`. Direct SMTP credentials never touch the codebase. Set `BREVO_API_KEY` in `.env` (sender domain SPF/DKIM verification still pending for production).
 
-**Spam & abuse protection — four-layer defense on `POST /contacts`:**
+**Spam & abuse protection — five-layer defense on `POST /contacts`:**
 
 1. **IP rate limiting** (`services/rateLimiter.js` → `limiter`) — Cheapest, broadest gate. 5 submissions per 15 minutes per IP, returns HTTP 429 with a friendly retry message. Requires `app.set("trust proxy", 1)` in `index.js` to read the real visitor IP through Render's reverse proxy — without it, every request resolves to the same proxy address and the limiter effectively becomes one shared bucket for the whole site.
 2. **Email rate limiting** (`services/rateLimiter.js` → `emailLimiter`) — Catches a sender who spreads submissions across the day from the same address (e.g. one an hour) to stay under the IP window. Keys on the submitted `email` field instead of IP: 3 submissions per 24 hours per address, regardless of which IP they came from.
 
 Both limiters store their hit counts via `services/fileRateLimitStore.js`, a small JSON-file-backed `Store` (implements the `express-rate-limit` `Store` interface), instead of the default in-memory store. That matters because Render's free tier spins the process down after idle time — with the default in-memory store, every restart silently reset every counter back to zero, so a slow, spread-out sender never accumulated a real block. The file lives under `RATE_LIMIT_DATA_DIR` (defaults to `data-runtime/` locally; set to `/app/data-runtime` in Docker, see below), so counts survive restarts. Both limiters also log to the console on every block (IP, email, name, timestamp) so blocked activity shows up in server/Render logs instead of being invisible.
 3. **Honeypot** (`routes/contacts.js`) — Hidden `website` input rendered off-screen with `aria-hidden="true"` and `tabindex="-1"` so screen readers and keyboard users skip it, but bots filling every field will trip it. Triggered submissions are logged server-side with IP + identifying info, then rendered a **fake success page** so the attacker doesn't learn the trap exists.
-4. **Validation** (`services/validateContact.js`) — Server-side checks on name (1–100), email (6–254 + format), category (whitelist), and message (10–2000). EJS templates auto-escape via `<%= %>` so any returned user input is XSS-safe. Errors render back to the form with the original values preserved.
+4. **hCaptcha** (`services/verifyCaptcha.js`, widget in `views/contacts.ejs`) — The layer the others can't cover: it verifies a human (not a script) submitted the form, regardless of what email/IP/name the sender uses. The widget only renders when `HCAPTCHA_SITE_KEY` is set; the server verifies the submitted `h-captcha-response` token against hCaptcha's `siteverify` API using `HCAPTCHA_SECRET_KEY`. If no secret is configured (e.g. local dev), verification is skipped so the form still works without it — configure both env vars to turn it on. A missing/failed token re-renders the form with a "please complete the verification challenge" message rather than a fake success, since this also catches legitimate users whose token expired or didn't load.
+5. **Validation** (`services/validateContact.js`) — Server-side checks on name (1–100), email (6–254 + format), category (whitelist), and message (10–2000). EJS templates auto-escape via `<%= %>` so any returned user input is XSS-safe. Errors render back to the form with the original values preserved.
 
 Defense is intentionally layered: each gate is cheaper and broader than the next. A bot has to rotate IPs faster than 5/15min, *and* rotate email addresses faster than 3/24h, *and* not fill the honeypot, *and* pass validation, before the email send is even attempted.
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -32,7 +32,8 @@ pit_stop_ministries/
 ├── services/
 │   ├── email.js              # Brevo transactional email client
 │   ├── validateContact.js    # Server-side validation for contact fields
-│   └── rateLimiter.js        # express-rate-limit config (5/15min per IP, 3/24h per email)
+│   ├── rateLimiter.js        # express-rate-limit config (5/15min per IP, 3/24h per email)
+│   └── fileRateLimitStore.js # Persists rate-limit counters to disk (survives restarts)
 ├── data/
 │   └── sermons.json          # Curated YouTube sermon library (id / title / date)
 ├── scripts/
@@ -70,6 +71,17 @@ pit_stop_ministries/
 - URL-encoded form body parsing (`express.urlencoded({ extended: true })`)
 - `morgan` request logging in dev mode
 - Centralized error handler — catches unhandled errors, returns clean 500 response
+- `app.set("trust proxy", 1)` — required for correct per-visitor IP detection behind Render's (or any) reverse proxy; see [Contact Page](#contact-page) spam defense
+
+### Docker
+
+`Dockerfile` + `docker-compose.yml` at the repo root run the same app in a container — `docker compose up --build` (after `cp .env.example .env`). Notes:
+
+- Base image `node:22-alpine`, matching the Node version the project is developed against (no `.nvmrc`/`engines` pin exists yet).
+- `npm ci --omit=dev` — production dependencies only (`nodemon`, a devDependency, is skipped).
+- Runs as the non-root `node` user built into the base image, not root.
+- `/app/data-runtime` (where `services/fileRateLimitStore.js` persists rate-limit counters) is mounted as a named volume (`rate-limit-data`) in `docker-compose.yml`, so counters survive `docker compose restart`/redeploys the same way they'd need to in any long-lived deployment.
+- This is currently an alternative way to run the app locally/self-hosted — production still deploys via `render.yaml`'s native Node runtime (Render also supports Docker-based services, but switching `render.yaml` to build from this image is a separate, not-yet-made decision).
 
 ## Routes
 
@@ -120,6 +132,8 @@ Form collects: name, email, category dropdown, message.
 
 1. **IP rate limiting** (`services/rateLimiter.js` → `limiter`) — Cheapest, broadest gate. 5 submissions per 15 minutes per IP, returns HTTP 429 with a friendly retry message. Requires `app.set("trust proxy", 1)` in `index.js` to read the real visitor IP through Render's reverse proxy — without it, every request resolves to the same proxy address and the limiter effectively becomes one shared bucket for the whole site.
 2. **Email rate limiting** (`services/rateLimiter.js` → `emailLimiter`) — Catches a sender who spreads submissions across the day from the same address (e.g. one an hour) to stay under the IP window. Keys on the submitted `email` field instead of IP: 3 submissions per 24 hours per address, regardless of which IP they came from.
+
+Both limiters store their hit counts via `services/fileRateLimitStore.js`, a small JSON-file-backed `Store` (implements the `express-rate-limit` `Store` interface), instead of the default in-memory store. That matters because Render's free tier spins the process down after idle time — with the default in-memory store, every restart silently reset every counter back to zero, so a slow, spread-out sender never accumulated a real block. The file lives under `RATE_LIMIT_DATA_DIR` (defaults to `data-runtime/` locally; set to `/app/data-runtime` in Docker, see below), so counts survive restarts. Both limiters also log to the console on every block (IP, email, name, timestamp) so blocked activity shows up in server/Render logs instead of being invisible.
 3. **Honeypot** (`routes/contacts.js`) — Hidden `website` input rendered off-screen with `aria-hidden="true"` and `tabindex="-1"` so screen readers and keyboard users skip it, but bots filling every field will trip it. Triggered submissions are logged server-side with IP + identifying info, then rendered a **fake success page** so the attacker doesn't learn the trap exists.
 4. **Validation** (`services/validateContact.js`) — Server-side checks on name (1–100), email (6–254 + format), category (whitelist), and message (10–2000). EJS templates auto-escape via `<%= %>` so any returned user input is XSS-safe. Errors render back to the form with the original values preserved.
 

--- a/data/sermons.json
+++ b/data/sermons.json
@@ -1,5 +1,11 @@
 [
     {
+        "id": "E_0DS5QPDUw",
+        "title": "The Pitt Stop | Jul 26, 2026",
+        "date": "2026-07-26",
+        "description": ""
+    },
+    {
         "id": "Emx62wYKAzs",
         "title": "The Pitt Stop | Jul 22, 2026",
         "date": "2026-07-22",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   web:
     build: .
+    restart: unless-stopped
     ports:
       - "3000:3000"
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    environment:
+      - PORT=3000
+    volumes:
+      - rate-limit-data:/app/data-runtime
+
+volumes:
+  rate-limit-data:

--- a/index.js
+++ b/index.js
@@ -16,6 +16,12 @@ const homeRouter = require("./routes/home")
 const app = express();
 const port = process.env.PORT || 3000;
 
+// Render sits in front of the app as a single reverse-proxy hop. Without this,
+// Express ignores the X-Forwarded-For header and req.ip resolves to Render's
+// internal proxy address for every request — collapsing per-visitor rate
+// limiting (services/rateLimiter.js) into one shared bucket for the whole site.
+app.set("trust proxy", 1);
+
 // Template engine = "ejs" - allows us to render dynamic HTML pages
 app.set("view engine", "ejs")
 app.set("views", path.join(__dirname, "views"));

--- a/routes/contacts.js
+++ b/routes/contacts.js
@@ -2,13 +2,13 @@ const express = require('express');
 const router = express.Router();
 const { sendContactEmail } = require("../services/email");
 const { validateContact } = require("../services/validateContact");
-const { limiter } = require("../services/rateLimiter");
+const { limiter, emailLimiter } = require("../services/rateLimiter");
 
 router.get("/", (req, res) => {
     res.render('contacts', { currentPage: 'contacts', errors: {}, values: {} });
 });
 
-router.post('/', limiter, async (req, res) => {
+router.post('/', limiter, emailLimiter, async (req, res) => {
     // Honey pot verification
     if (req.body.website) {
         console.log('Honeypot triggered', {

--- a/routes/contacts.js
+++ b/routes/contacts.js
@@ -2,10 +2,13 @@ const express = require('express');
 const router = express.Router();
 const { sendContactEmail } = require("../services/email");
 const { validateContact } = require("../services/validateContact");
+const { verifyCaptcha } = require("../services/verifyCaptcha");
 const { limiter, emailLimiter } = require("../services/rateLimiter");
 
+const hcaptchaSiteKey = process.env.HCAPTCHA_SITE_KEY;
+
 router.get("/", (req, res) => {
-    res.render('contacts', { currentPage: 'contacts', errors: {}, values: {} });
+    res.render('contacts', { currentPage: 'contacts', errors: {}, values: {}, hcaptchaSiteKey });
 });
 
 router.post('/', limiter, emailLimiter, async (req, res) => {
@@ -21,11 +24,27 @@ router.post('/', limiter, emailLimiter, async (req, res) => {
         return;
     }
 
+    const captchaOk = await verifyCaptcha(req.body['h-captcha-response'], req.ip);
+    if (!captchaOk) {
+        const values = {
+            name: req.body.name,
+            email: req.body.email,
+            category: req.body.category,
+            message: req.body.message,
+        };
+        return res.render('contacts', {
+            currentPage: 'contacts',
+            errors: { captcha: 'Please complete the verification challenge and try again.' },
+            values,
+            hcaptchaSiteKey,
+        });
+    }
+
     // Gets back errors (which fields failed) + values (what user typed)
     const { errors, values } = validateContact(req.body);
 
     if (Object.keys(errors).length > 0) {
-        return res.render('contacts', { currentPage: 'contacts', errors, values });
+        return res.render('contacts', { currentPage: 'contacts', errors, values, hcaptchaSiteKey });
     }
     try {
         await sendContactEmail(values);

--- a/services/fileRateLimitStore.js
+++ b/services/fileRateLimitStore.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+const path = require('path');
+
+// express-rate-limit's default MemoryStore lives entirely in process memory,
+// so every counter resets to zero whenever the process restarts (a Render
+// free-tier dyno spinning down after idle time, a redeploy, a crash, etc).
+// That silently un-does any guardrail built on top of it. This Store
+// implementation persists hit counts to a JSON file on disk so they survive
+// restarts — pair it with a mounted Docker volume for the data directory.
+class FileRateLimitStore {
+    constructor(filePath) {
+        this.filePath = filePath;
+        this.windowMs = 0;
+        this.data = new Map();
+        this._load();
+    }
+
+    init(options) {
+        this.windowMs = options.windowMs;
+    }
+
+    _load() {
+        try {
+            const raw = fs.readFileSync(this.filePath, 'utf8');
+            const parsed = JSON.parse(raw);
+            this.data = new Map(
+                Object.entries(parsed).map(([key, entry]) => [
+                    key,
+                    { totalHits: entry.totalHits, resetTime: new Date(entry.resetTime) },
+                ])
+            );
+        } catch {
+            this.data = new Map();
+        }
+    }
+
+    _save() {
+        const serialized = {};
+        for (const [key, entry] of this.data) {
+            serialized[key] = { totalHits: entry.totalHits, resetTime: entry.resetTime.toISOString() };
+        }
+        fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+        fs.writeFileSync(this.filePath, JSON.stringify(serialized));
+    }
+
+    _activeEntry(key) {
+        const entry = this.data.get(key);
+        if (!entry || entry.resetTime.getTime() <= Date.now()) return undefined;
+        return entry;
+    }
+
+    get(key) {
+        const entry = this._activeEntry(key);
+        return entry ? { totalHits: entry.totalHits, resetTime: entry.resetTime } : undefined;
+    }
+
+    increment(key) {
+        const entry = this._activeEntry(key) ?? { totalHits: 0, resetTime: new Date(Date.now() + this.windowMs) };
+        entry.totalHits += 1;
+        this.data.set(key, entry);
+        this._save();
+        return { totalHits: entry.totalHits, resetTime: entry.resetTime };
+    }
+
+    decrement(key) {
+        const entry = this.data.get(key);
+        if (entry && entry.totalHits > 0) {
+            entry.totalHits -= 1;
+            this._save();
+        }
+    }
+
+    resetKey(key) {
+        this.data.delete(key);
+        this._save();
+    }
+
+    resetAll() {
+        this.data.clear();
+        this._save();
+    }
+}
+
+module.exports = { FileRateLimitStore };

--- a/services/rateLimiter.js
+++ b/services/rateLimiter.js
@@ -1,4 +1,20 @@
+const path = require('path');
 const { rateLimit, ipKeyGenerator } = require('express-rate-limit');
+const { FileRateLimitStore } = require('./fileRateLimitStore');
+
+// Where hit counts are persisted so they survive process restarts (Render
+// free-tier idle spin-down, redeploys, crashes). Point RATE_LIMIT_DATA_DIR at
+// a mounted volume in Docker so this directory isn't wiped with the container.
+const dataDir = process.env.RATE_LIMIT_DATA_DIR || path.join(__dirname, '..', 'data-runtime');
+
+function logBlocked(label, req) {
+    console.log(`Rate limit blocked (${label})`, {
+        ip: req.ip,
+        email: req.body?.email,
+        name: req.body?.name,
+        timestamp: new Date(),
+    });
+}
 
 const limiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
@@ -6,6 +22,11 @@ const limiter = rateLimit({
     message: 'Too many submissions. Please wait a few minutes and try again.',
     standardHeaders: true, // Return rate limit info in the 'RateLimit-x' headers
     legacyHeaders: false, // Disable the X-RateLimit-* headers
+    store: new FileRateLimitStore(path.join(dataDir, 'ip-limiter.json')),
+    handler: (req, res, next, options) => {
+        logBlocked('per-IP', req);
+        res.status(options.statusCode).send(options.message);
+    },
 });
 
 // Per-IP limiting alone doesn't stop a sender who spreads submissions across
@@ -18,17 +39,15 @@ const emailLimiter = rateLimit({
     message: 'Too many submissions from this email today. Please wait and try again tomorrow.',
     standardHeaders: true,
     legacyHeaders: false,
+    store: new FileRateLimitStore(path.join(dataDir, 'email-limiter.json')),
     keyGenerator: (req) => {
         const email = typeof req.body?.email === 'string' ? req.body.email.trim().toLowerCase() : '';
         return email || ipKeyGenerator(req.ip);
     },
+    handler: (req, res, next, options) => {
+        logBlocked('per-email', req);
+        res.status(options.statusCode).send(options.message);
+    },
 });
 
 module.exports = { limiter, emailLimiter };
-
-/* Set a custom handler for more advanced use-cases, such as using res.render() to send a templated response.
-​
-statusCode
-number
-The HTTP status code to send back when a client is rate limited.
-Defaults to 429.*/

--- a/services/rateLimiter.js
+++ b/services/rateLimiter.js
@@ -1,4 +1,4 @@
-const { rateLimit } = require('express-rate-limit');
+const { rateLimit, ipKeyGenerator } = require('express-rate-limit');
 
 const limiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
@@ -8,7 +8,23 @@ const limiter = rateLimit({
     legacyHeaders: false, // Disable the X-RateLimit-* headers
 });
 
-module.exports = { limiter };
+// Per-IP limiting alone doesn't stop a sender who spreads submissions across
+// the day from the same address (e.g. one every hour) — that stays well under
+// the window above. This limiter keys on the submitted email instead, so the
+// same sender is capped regardless of IP.
+const emailLimiter = rateLimit({
+    windowMs: 24 * 60 * 60 * 1000, // 24 hours
+    limit: 3, // Limit each email address to 3 requests per day
+    message: 'Too many submissions from this email today. Please wait and try again tomorrow.',
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req) => {
+        const email = typeof req.body?.email === 'string' ? req.body.email.trim().toLowerCase() : '';
+        return email || ipKeyGenerator(req.ip);
+    },
+});
+
+module.exports = { limiter, emailLimiter };
 
 /* Set a custom handler for more advanced use-cases, such as using res.render() to send a templated response.
 ​

--- a/services/verifyCaptcha.js
+++ b/services/verifyCaptcha.js
@@ -1,0 +1,28 @@
+const HCAPTCHA_VERIFY_URL = 'https://api.hcaptcha.com/siteverify';
+
+// Verifies the "h-captcha-response" token hCaptcha's widget adds to the form.
+// If no secret is configured (e.g. local dev without hCaptcha set up yet),
+// verification is skipped so the form still works without it.
+async function verifyCaptcha(token, remoteip) {
+    const secret = process.env.HCAPTCHA_SECRET_KEY;
+    if (!secret) return true;
+    if (!token) return false;
+
+    const params = new URLSearchParams({ secret, response: token });
+    if (remoteip) params.set('remoteip', remoteip);
+
+    try {
+        const response = await fetch(HCAPTCHA_VERIFY_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params,
+        });
+        const data = await response.json();
+        return data.success === true;
+    } catch (error) {
+        console.error('hCaptcha verification request failed:', error);
+        return false;
+    }
+}
+
+module.exports = { verifyCaptcha };

--- a/views/contacts.ejs
+++ b/views/contacts.ejs
@@ -48,6 +48,9 @@
       gtag('js', new Date());
       gtag('config', 'G-2H8RJXLDZR');
     </script>
+    <% if (typeof hcaptchaSiteKey !== 'undefined' && hcaptchaSiteKey) { %>
+        <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
+    <% } %>
 </head>
 <body>
     <%- include('partials/nav') %>
@@ -107,6 +110,15 @@
                 </div>
 
                 <input type="text" name="website" id="website" aria-hidden="true" tabindex="-1" class="hp-field">
+
+                <% if (typeof hcaptchaSiteKey !== 'undefined' && hcaptchaSiteKey) { %>
+                    <div class="field <%= errors.captcha ? 'field--error' : '' %>">
+                        <div class="h-captcha" data-sitekey="<%= hcaptchaSiteKey %>"></div>
+                        <% if (errors.captcha) { %>
+                            <p class="error"><%= errors.captcha %></p>
+                        <% } %>
+                    </div>
+                <% } %>
 
                 <button type="submit" class="btn-submit">Send Message</button>
             </form>


### PR DESCRIPTION
## Summary

This PR significantly strengthens the contact form's spam defense and adds Docker containerization support. The changes introduce persistent rate limiting that survives process restarts, hCaptcha bot verification, and a two-tier rate-limiting strategy (per-IP and per-email).

## Key Changes

- **Persistent Rate Limiting** — Created `FileRateLimitStore` class that persists rate-limit hit counts to disk as JSON, surviving process restarts (Render free-tier idle spin-downs, redeploys, crashes). Counters are stored in a configurable `RATE_LIMIT_DATA_DIR` directory.

- **Dual Rate-Limit Strategy** — Enhanced `rateLimiter.js` with two complementary limiters:
  - `limiter`: 5 submissions per 15 minutes per IP (broad, cheap gate)
  - `emailLimiter`: 3 submissions per 24 hours per email address (catches distributed attacks from same sender across different IPs)

- **hCaptcha Integration** — Added `verifyCaptcha.js` service that validates hCaptcha tokens server-side. Gracefully degrades if `HCAPTCHA_SECRET_KEY` is not configured (useful for local development). Updated contact form view to render the hCaptcha widget when configured.

- **Docker Support** — Added `Dockerfile` (Node 22 Alpine base, production dependencies only, runs as non-root `node` user) and `docker-compose.yml` with a named volume for persisting rate-limit counters across container restarts.

- **Reverse Proxy Configuration** — Added `app.set("trust proxy", 1)` in `index.js` to correctly read visitor IPs through Render's reverse proxy, ensuring per-IP rate limiting works as intended.

- **Documentation Updates** — Updated README with Docker quickstart, WIKI.md with detailed architecture notes on rate limiting, Docker setup, and the five-layer spam defense strategy.

## Notable Implementation Details

- Rate-limit data is serialized to JSON with ISO timestamp strings for `resetTime` and deserialized back to `Date` objects on load.
- The `emailLimiter` falls back to IP-based keying if no email is provided, ensuring all submissions are rate-limited.
- hCaptcha verification includes the visitor's IP for additional fraud detection signals.
- `.dockerignore` excludes runtime data and documentation to keep the image lean.
- `data-runtime/` directory is gitignored since it contains runtime state, not source code.

https://claude.ai/code/session_01K676Jyw5Np7sjnYwLEyPck